### PR TITLE
fix #58 - Export PDF : update artifact in pom files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -834,8 +834,8 @@
                         <artifactId>jericho-html</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>com.lowagie</groupId>
-                        <artifactId>itext</artifactId>
+                        <groupId>com.itextpdf</groupId>
+                        <artifactId>itextpdf</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>junit</groupId>
@@ -1081,8 +1081,8 @@
                         <artifactId>commons-lang</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>com.lowagie</groupId>
-                        <artifactId>itext</artifactId>
+                        <groupId>com.itextpdf</groupId>
+                        <artifactId>itextpdf</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1137,8 +1137,8 @@
                         <artifactId>bctsp-jdk14</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>com.lowagie</groupId>
-                        <artifactId>itext</artifactId>
+                        <groupId>com.itextpdf</groupId>
+                        <artifactId>itextpdf</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>poi</groupId>
@@ -1168,9 +1168,9 @@
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>com.lowagie</groupId>
-                <artifactId>itext</artifactId>
-                <version>4.2.1</version>
+                <groupId>com.itextpdf</groupId>
+                <artifactId>itextpdf</artifactId>
+                <version>5.5.8</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.bouncycastle</groupId>

--- a/web-app/tgol-report/pom.xml
+++ b/web-app/tgol-report/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>jasperreports</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.lowagie</groupId>
-            <artifactId>itext</artifactId>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>itextpdf</artifactId>
         </dependency>
         <dependency>
             <groupId>net.sf.jasperreports</groupId>


### PR DESCRIPTION
I tested and the PDF export works.

@jkowalczyk @mfaure could you review this patch ?
 if it's is Ok for you, I myself manage the merge.

------------
log "mvn clean install"
```
[WARNING] The artifact com.lowagie:itext:jar:4.2.1
has been relocated to com.itextpdf:itextpdf:jar:5.5.*
```

same information to following URL
http://mvnrepository.com/artifact/com.lowagie/itext/4.2.