### PR TITLE
Modifiers should be declared in the correct order

### DIFF
--- a/engine/asqatasun-api/src/main/java/org/asqatasun/ruleimplementation/AbstractPageRuleDefaultImplementation.java
+++ b/engine/asqatasun-api/src/main/java/org/asqatasun/ruleimplementation/AbstractPageRuleDefaultImplementation.java
@@ -81,13 +81,13 @@ public abstract class AbstractPageRuleDefaultImplementation extends AbstractPage
      * @param testSolutionHandler
      *            the testSolutionHandler that handles the computed TestSolutions.
      */
-    abstract protected void selectAndCheck(SSPHandler sspHandler, TestSolutionHandler testSolutionHandler);
+    protected abstract void selectAndCheck(SSPHandler sspHandler, TestSolutionHandler testSolutionHandler);
     
     /**
      * 
      * @return The total number of elements implied by test.
      */
-    abstract protected int getSelectionSize();
+    protected abstract int getSelectionSize();
     
     /**
      * This method computes the {@link DefiniteResult} of the test from the

--- a/engine/asqatasun-api/src/main/java/org/asqatasun/ruleimplementation/AbstractPageRuleMarkupImplementation.java
+++ b/engine/asqatasun-api/src/main/java/org/asqatasun/ruleimplementation/AbstractPageRuleMarkupImplementation.java
@@ -61,7 +61,7 @@ public abstract class AbstractPageRuleMarkupImplementation
      * @param sspHandler
      *            the SSP handler to use.
      */
-    abstract protected void select(SSPHandler sspHandler);
+    protected abstract void select(SSPHandler sspHandler);
     
     /**
      * This method defines a check operation . The instance of 
@@ -77,11 +77,11 @@ public abstract class AbstractPageRuleMarkupImplementation
      * @param testSolutionHandler
      *            the testSolutionHandler that handles the computed TestSolutions.
      */
-    abstract protected void check(
+    protected abstract void check(
                 SSPHandler sspHandler,
                 TestSolutionHandler testSolutionHandler);
 
     @Override
-    abstract public int getSelectionSize();
+    public abstract int getSelectionSize();
 
 }

--- a/engine/contentadapter/src/main/java/org/asqatasun/contentadapter/util/HtmlNodeAttr.java
+++ b/engine/contentadapter/src/main/java/org/asqatasun/contentadapter/util/HtmlNodeAttr.java
@@ -32,14 +32,14 @@ public abstract class HtmlNodeAttr {
      */
     private HtmlNodeAttr() {}
     
-    public final static String CLASS = "class";
-    public final static String HREF = "href";
-    public final static String ID = "id";
-    public final static String LINK = "link";
-    public final static String REL = "rel";
-    public final static String SRC = "src";
-    public final static String STYLE = "style";
-    public final static String MEDIA = "media";
-    public final static String TYPE = "type";
+    public static final String CLASS = "class";
+    public static final String HREF = "href";
+    public static final String ID = "id";
+    public static final String LINK = "link";
+    public static final String REL = "rel";
+    public static final String SRC = "src";
+    public static final String STYLE = "style";
+    public static final String MEDIA = "media";
+    public static final String TYPE = "type";
 
 }

--- a/engine/contentadapter/src/main/java/org/asqatasun/contentadapter/util/HtmlTags.java
+++ b/engine/contentadapter/src/main/java/org/asqatasun/contentadapter/util/HtmlTags.java
@@ -27,9 +27,9 @@ package org.asqatasun.contentadapter.util;
  */
 public abstract class HtmlTags {
 
-    public final static String LINK = "link";
-    public final static String SCRIPT = "script";
-    public final static String STYLE = "style";
-    public final static String BASE = "base";
+    public static final String LINK = "link";
+    public static final String SCRIPT = "script";
+    public static final String STYLE = "style";
+    public static final String BASE = "base";
 
 }

--- a/rules/rules-accessiweb2.2/src/main/java/org/asqatasun/rules/accessiweb22/Aw22Rule10071.java
+++ b/rules/rules-accessiweb2.2/src/main/java/org/asqatasun/rules/accessiweb22/Aw22Rule10071.java
@@ -59,7 +59,7 @@ public class Aw22Rule10071 extends AbstractPageRuleFromPreProcessImplementation 
      * For these elements, the extraction is not trusted, the default value
      * depends on the browser and may be confusable
      */
-    private final static String[] FOCUSABLE_EXCLUDED_LIST = 
+    private static final String[] FOCUSABLE_EXCLUDED_LIST = 
             {HtmlElementStore.INPUT_ELEMENT, 
              HtmlElementStore.BUTTON_ELEMENT, 
              HtmlElementStore.TEXTAREA_ELEMENT, 

--- a/rules/rules-seo1.0/src/main/java/org/asqatasun/rules/seo/SeoRule01013.java
+++ b/rules/rules-seo1.0/src/main/java/org/asqatasun/rules/seo/SeoRule01013.java
@@ -41,7 +41,7 @@ import org.asqatasun.rules.textbuilder.TextAttributeOfElementBuilder;
  */
 public class SeoRule01013 extends AbstractPageRuleMarkupImplementation {
 
-    private final static int MAX_META_DESC_LENGTH = 255;
+    private static final int MAX_META_DESC_LENGTH = 255;
     private final ElementHandler<Element> elementHandler = new ElementHandlerImpl();
     
     /*

--- a/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/command/helper/UploadAuditSetUpCommandHelper.java
+++ b/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/command/helper/UploadAuditSetUpCommandHelper.java
@@ -44,7 +44,7 @@ public final class UploadAuditSetUpCommandHelper  {
      * This method converts the uploaded files into a map where the key is the
      * file name and the value is the file content.
      */
-    public synchronized  static Map<String, String> convertFilesToMap(CommonsMultipartFile[] fileInputList ) {
+    public static synchronized Map<String, String> convertFilesToMap(CommonsMultipartFile[] fileInputList ) {
         Map<String, String> fileMap = new LinkedHashMap<String, String>();
         CommonsMultipartFile tmpMultiFile;
         String tmpCharset;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
Please let me know if you have any questions.
Ayman Abdelghany.