### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/engine/commons-processing/src/main/java/org/asqatasun/processing/ProcessRemarkServiceFactory.java
+++ b/engine/commons-processing/src/main/java/org/asqatasun/processing/ProcessRemarkServiceFactory.java
@@ -32,6 +32,9 @@ import org.asqatasun.service.ProcessRemarkService;
  */
 public class ProcessRemarkServiceFactory {
 
+    private ProcessRemarkServiceFactory() {
+    }
+
     /**
      *
      * @param processRemarkFactory

--- a/engine/processor/src/main/java/org/asqatasun/processor/CSSHandlerFactory.java
+++ b/engine/processor/src/main/java/org/asqatasun/processor/CSSHandlerFactory.java
@@ -29,6 +29,9 @@ import org.asqatasun.service.ProcessRemarkService;
  */
 public class CSSHandlerFactory {
 
+    private CSSHandlerFactory() {
+    }
+
     /**
      * 
      * @param processRemarkService

--- a/engine/processor/src/main/java/org/asqatasun/processor/DOMHandlerFactory.java
+++ b/engine/processor/src/main/java/org/asqatasun/processor/DOMHandlerFactory.java
@@ -27,7 +27,9 @@ import org.asqatasun.service.ProcessRemarkService;
  *
  * @author enzolalay
  */
-public class DOMHandlerFactory {// TODO Write javadoc
+public class DOMHandlerFactory {
+    private DOMHandlerFactory() {
+    }// TODO Write javadoc
 
     public static DOMHandler create(ProcessRemarkService processRemarkService) {
         DOMHandler domHandler = new DOMHandlerImpl();

--- a/engine/processor/src/main/java/org/asqatasun/processor/SSPHandlerFactory.java
+++ b/engine/processor/src/main/java/org/asqatasun/processor/SSPHandlerFactory.java
@@ -32,6 +32,9 @@ import org.asqatasun.service.ProcessRemarkService;
  */
 public class SSPHandlerFactory {
 
+    private SSPHandlerFactory() {
+    }
+
     public static SSPHandler create(
             ProcessRemarkService processRemarkService, 
             NomenclatureLoaderService nomenclatureLoaderService, 

--- a/rules/rules-commons/src/main/java/org/asqatasun/rules/elementchecker/helper/RuleCheckHelper.java
+++ b/rules/rules-commons/src/main/java/org/asqatasun/rules/elementchecker/helper/RuleCheckHelper.java
@@ -30,6 +30,9 @@ public final class RuleCheckHelper {
 
     private static final String MSG_SPACER = "_";
 
+    private RuleCheckHelper() {
+    }
+
     /**
      * 
      * @param msg

--- a/testing-tools/rules-doc-utils/src/main/java/org/asqatasun/rules/doc/utils/exportdomtocsv/ExportDomToCsv.java
+++ b/testing-tools/rules-doc-utils/src/main/java/org/asqatasun/rules/doc/utils/exportdomtocsv/ExportDomToCsv.java
@@ -38,6 +38,9 @@ public class ExportDomToCsv {
 
     private static final String FOLDER = "$path_to_csv_file";
 
+    private ExportDomToCsv() {
+    }
+
     /**
      * Before using it please set the FOLDER variable with the path where you
      * want to create your csv file.

--- a/testing-tools/rules-doc-utils/src/main/java/org/asqatasun/rules/doc/utils/rga33/extractor/Rgaa3Extractor.java
+++ b/testing-tools/rules-doc-utils/src/main/java/org/asqatasun/rules/doc/utils/rga33/extractor/Rgaa3Extractor.java
@@ -78,7 +78,10 @@ public class Rgaa3Extractor {
     
     static final Map<String, String> levelFromCrit = new LinkedHashMap<>();
     static boolean writeCritInFile = false;
-    
+
+    private Rgaa3Extractor() {
+    }
+
     /**
      * @param args the command line arguments
      * @throws java.io.IOException

--- a/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/command/helper/ContractSortCommandHelper.java
+++ b/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/command/helper/ContractSortCommandHelper.java
@@ -43,6 +43,10 @@ import org.springframework.ui.Model;
 public final class ContractSortCommandHelper  {
 
     private static String lastAuditMarkSortValue;
+
+    private ContractSortCommandHelper() {
+    }
+
     public static String getLastAuditMarkSortValue() {
         return lastAuditMarkSortValue;
     }

--- a/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/command/helper/UploadAuditSetUpCommandHelper.java
+++ b/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/command/helper/UploadAuditSetUpCommandHelper.java
@@ -39,7 +39,10 @@ public final class UploadAuditSetUpCommandHelper  {
      */
     private static Map<String, Integer> fileNameCounterMap = 
             new HashMap<String, Integer>();
-    
+
+    private UploadAuditSetUpCommandHelper() {
+    }
+
     /**
      * This method converts the uploaded files into a map where the key is the
      * file name and the value is the file content.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.