### PR TITLE
 Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/engine/analyser/src/main/java/org/asqatasun/service/AnalyserServiceImpl.java
+++ b/engine/analyser/src/main/java/org/asqatasun/service/AnalyserServiceImpl.java
@@ -42,12 +42,21 @@ public class AnalyserServiceImpl implements AnalyserService {
         super();
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param netResultList
+     * @return
+     */
     @Override
     @Deprecated
     public float analyse(List<ProcessResult> netResultList) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param analyser
+     */
     @Override
     @Deprecated
     public void setAnalyser(Analyser analyser) {

--- a/engine/asqatasun-api/src/main/java/org/asqatasun/analyser/Analyser.java
+++ b/engine/asqatasun-api/src/main/java/org/asqatasun/analyser/Analyser.java
@@ -32,7 +32,7 @@ import org.asqatasun.entity.subject.WebResource;
 public interface Analyser {
 
     /**
-     *
+     * @deprecated Kept for backward compatibility.
      * @return the net result list
      */
     @Deprecated
@@ -50,7 +50,7 @@ public interface Analyser {
     void run();
 
     /**
-     *
+     * @deprecated Kept for backward compatibility.
      * @param netResultList the result list to set
      */
     @Deprecated

--- a/engine/asqatasun-api/src/main/java/org/asqatasun/service/AnalyserService.java
+++ b/engine/asqatasun-api/src/main/java/org/asqatasun/service/AnalyserService.java
@@ -37,7 +37,7 @@ import org.asqatasun.entity.subject.WebResource;
 public interface AnalyserService {
 
     /**
-     *
+     * @deprecated Kept for backward compatibility.
      * @param netResultList
      * @return
      */
@@ -52,7 +52,7 @@ public interface AnalyserService {
     void analyse(WebResource webResource, Audit audit);
 
     /**
-     * 
+     * @deprecated Kept for backward compatibility.
      * @param analyser
      */
     @Deprecated

--- a/engine/processor/src/main/java/org/asqatasun/processor/DOMHandlerImpl.java
+++ b/engine/processor/src/main/java/org/asqatasun/processor/DOMHandlerImpl.java
@@ -651,12 +651,22 @@ public class DOMHandlerImpl implements DOMHandler {
         this.processRemarkService = processRemarkService;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Override
     @Deprecated
     public String getMessageCode() {
         return messageCode;
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to check
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler selectDocumentNodesWithAttribute(String attributeName) {
@@ -669,7 +679,13 @@ public class DOMHandlerImpl implements DOMHandler {
         selectedElementList = elements;
         return this;
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to check
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkAttributeValueIsEmpty(String attributeName) {
@@ -692,6 +708,12 @@ public class DOMHandlerImpl implements DOMHandler {
         return RuleHelper.synthesizeTestSolutionCollection(resultSet);
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeNames
+     *            the names of the childnodes to select recursively
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler selectChildNodesRecursively(
@@ -708,6 +730,12 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeNames
+     *            the names of the childnodes to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler keepNodesWithoutChildNode(
@@ -733,6 +761,11 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeName
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler keepNodesWithoutChildNode(String childNodeName) {
@@ -755,6 +788,11 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param name
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler selectAttributeByName(String name) {
@@ -769,6 +807,12 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeNames
+     *            the names of the childNodes to select
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler selectChildNodes(Collection<String> childNodeNames) {
@@ -790,7 +834,15 @@ public class DOMHandlerImpl implements DOMHandler {
         selectedElementList = elements;
         return this;
     }
-  
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to filter
+     * @param values
+     *            the values of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler keepNodesWithAttributeValueEquals(String attributeName,
@@ -813,6 +865,12 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler keepNodesWithAttributeValueNonEmpty(String attributeName) {
@@ -828,6 +886,14 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to be filteterd
+     * @param values
+     *            the values of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler keepNodesWithAttributeValueStartingWith(
@@ -851,6 +917,14 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to filter
+     * @param value
+     *            the value of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler keepNodesWithAttributeValueStartingWith(
@@ -872,6 +946,10 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Override
     @Deprecated
     public List<String> getTextContentValues() {
@@ -882,6 +960,14 @@ public class DOMHandlerImpl implements DOMHandler {
         return values;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param length
+     *            the length of the text content to check
+     * @param defaultFailResult
+     *            the default return value if the check processing fails
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkTextContentValueLengthLower(int length,
@@ -901,6 +987,10 @@ public class DOMHandlerImpl implements DOMHandler {
         return RuleHelper.synthesizeTestSolutionCollection(resultSet);
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkTextContentValueNotEmpty() {
@@ -917,6 +1007,12 @@ public class DOMHandlerImpl implements DOMHandler {
         return RuleHelper.synthesizeTestSolutionCollection(resultSet);
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler excludeNodesWithAttribute(String attributeName) {
@@ -932,6 +1028,12 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeNames
+     *            the names of the childnodes to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler excludeNodesWithChildNode(ArrayList<String> childNodeNames) {
@@ -957,6 +1059,12 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeName
+     *            the name of the childNode to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler excludeNodesWithChildNode(String childNodeName) {
@@ -979,6 +1087,12 @@ public class DOMHandlerImpl implements DOMHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute targeted
+     * @return
+     */
     @Override
     @Deprecated
     public List<String> getAttributeValues(String attributeName) {
@@ -993,6 +1107,15 @@ public class DOMHandlerImpl implements DOMHandler {
         return values;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     * @param blacklist
+     *            the list of prevented values
+     * @param whitelist
+     *            the list of granted values
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkTextContentAndAttributeValue(String attributeName,
@@ -1061,7 +1184,13 @@ public class DOMHandlerImpl implements DOMHandler {
 
         return RuleHelper.synthesizeTestSolutionCollection(resultSet);
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeName
+     *            the name of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler keepNodesWithChildNode(String childNodeName) {
@@ -1078,7 +1207,13 @@ public class DOMHandlerImpl implements DOMHandler {
         selectedElementList = elements;
         return this;
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeName
+     *            the name of the childnode to check
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkChildNodeExistsRecursively(String childNodeName) {
@@ -1102,7 +1237,11 @@ public class DOMHandlerImpl implements DOMHandler {
         }
         return RuleHelper.synthesizeTestSolutionCollection(resultSet);
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkContentNotEmpty() {
@@ -1121,7 +1260,12 @@ public class DOMHandlerImpl implements DOMHandler {
         }
         return RuleHelper.synthesizeTestSolutionCollection(resultSet);
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param expr
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkEachWithXpath(String expr) {
@@ -1146,7 +1290,13 @@ public class DOMHandlerImpl implements DOMHandler {
         }
         return RuleHelper.synthesizeTestSolutionCollection(resultSet);
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to check
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkAttributeValueNotEmpty(String attributeName) {
@@ -1168,7 +1318,15 @@ public class DOMHandlerImpl implements DOMHandler {
         }
         return RuleHelper.synthesizeTestSolutionCollection(resultSet);
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param blacklist
+     *            the list of prevented values
+     * @param whitelist
+     *            the list of granted values
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkNodeValue(Collection<String> blacklist,
@@ -1177,6 +1335,16 @@ public class DOMHandlerImpl implements DOMHandler {
                 "BlackListedValue");
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to check
+     * @param length
+     *            the length of the attribute value to check
+     * @param defaultFailResult
+     *            the default return value if the check processing fails
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkAttributeValueLengthLower(String attributeName,

--- a/engine/processor/src/main/java/org/asqatasun/processor/SSPHandlerImpl.java
+++ b/engine/processor/src/main/java/org/asqatasun/processor/SSPHandlerImpl.java
@@ -490,25 +490,50 @@ public class SSPHandlerImpl implements SSPHandler {
     public Collection<StylesheetContent> getStyleSheetOnError() {
         return cssHandler.getStyleSheetOnError();
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeName
+     *            the name of the childnode to check
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkChildNodeExistsRecursively(String childNodeName) {
         return domHandler.checkChildNodeExistsRecursively(childNodeName);
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkContentNotEmpty() {
         return domHandler.checkContentNotEmpty();
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param expr
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkEachWithXpath(String expr) {
         return domHandler.checkEachWithXpath(expr);
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to check
+     * @param blacklist
+     *            the list of prevented values
+     * @param whitelist
+     *            the list of granted values
+     * @return
+     */
     @Override  
     @Deprecated
     public TestSolution checkTextContentAndAttributeValue(String attributeName,
@@ -516,7 +541,15 @@ public class SSPHandlerImpl implements SSPHandler {
         return domHandler.checkTextContentAndAttributeValue(attributeName,
                 blacklist, whitelist);
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param length
+     *            the length of the text content to check
+     * @param defaultFailResult
+     *            the default return value if the check processing fails
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkTextContentValueLengthLower(int length,
@@ -525,18 +558,34 @@ public class SSPHandlerImpl implements SSPHandler {
                 defaultFailResult);
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkTextContentValueNotEmpty() {
         return domHandler.checkTextContentValueNotEmpty();
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public DOMHandler excludeNodesWithAttribute(String attributeName) {
         return domHandler.excludeNodesWithAttribute(attributeName);
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeNames
+     *            the names of the childnodes to filter
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler excludeNodesWithChildNode(ArrayList<String> childNodeNames) {
@@ -544,6 +593,12 @@ public class SSPHandlerImpl implements SSPHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeName
+     *            the name of the childNode to filter
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler excludeNodesWithChildNode(String childNodeName) {
@@ -551,18 +606,36 @@ public class SSPHandlerImpl implements SSPHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute targeted
+     * @return
+     */
     @Override
     @Deprecated
     public List<String> getAttributeValues(String attributeName) {
         return domHandler.getAttributeValues(attributeName);
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Override
     @Deprecated
     public List<String> getTextContentValues() {
         return domHandler.getTextContentValues();
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to filter
+     * @param values
+     *            the values of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler keepNodesWithAttributeValueEquals(String attributeName,
@@ -571,6 +644,12 @@ public class SSPHandlerImpl implements SSPHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler keepNodesWithAttributeValueNonEmpty(String attributeName) {
@@ -578,6 +657,14 @@ public class SSPHandlerImpl implements SSPHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to be filteterd
+     * @param values
+     *            the values of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler keepNodesWithAttributeValueStartingWith(
@@ -587,6 +674,14 @@ public class SSPHandlerImpl implements SSPHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to filter
+     * @param value
+     *            the value of the attribute to filter
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler keepNodesWithAttributeValueStartingWith(
@@ -594,7 +689,13 @@ public class SSPHandlerImpl implements SSPHandler {
         domHandler.keepNodesWithAttributeValueStartingWith(attributeName, value);
         return this;
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeNames
+     *            the names of the childnodes to filter
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler keepNodesWithoutChildNode(
@@ -603,13 +704,25 @@ public class SSPHandlerImpl implements SSPHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeName
+     *            the name of the childnode to filter
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler keepNodesWithoutChildNode(String childNodeName) {
         domHandler.keepNodesWithChildNode(childNodeName);
         return this;
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the atribute to select
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler selectAttributeByName(String attributeName) {
@@ -617,13 +730,25 @@ public class SSPHandlerImpl implements SSPHandler {
         return this;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeNames
+     *            the names of the childNodes to select
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler selectChildNodes(Collection<String> childNodeNames) {
         domHandler.selectChildNodes(childNodeNames);
         return this;
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param childNodeNames
+     *            the names of the childnodes to select recursively
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler selectChildNodesRecursively(
@@ -631,33 +756,67 @@ public class SSPHandlerImpl implements SSPHandler {
         domHandler.selectChildNodesRecursively(childNodeNames);
         return this;
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to check
+     * @return
+     */
     @Override
     @Deprecated
     public SSPHandler selectDocumentNodesWithAttribute(String attributeName) {
         domHandler.selectDocumentNodesWithAttribute(attributeName);
         return this;
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to check
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkAttributeValueIsEmpty(String attributeName) {
         return domHandler.checkAttributeValueIsEmpty(attributeName);
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Override
     @Deprecated
     public String getMessageCode() {
         return domHandler.getMessageCode();
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param blacklist
+     *            the list of prevented values
+     * @param whitelist
+     *            the list of granted values
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkNodeValue(Collection<String> blacklist,
             Collection<String> whitelist) {
         return domHandler.checkNodeValue(blacklist, whitelist);
     }
-    
+
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to check
+     * @param length
+     *            the length of the attribute value to check
+     * @param defaultFailResult
+     *            the default return value if the check processing fails
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkAttributeValueLengthLower(String attributeName,
@@ -666,6 +825,12 @@ public class SSPHandlerImpl implements SSPHandler {
                 defaultFailResult);
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param attributeName
+     *            the name of the attribute to check
+     * @return
+     */
     @Override
     @Deprecated
     public TestSolution checkAttributeValueNotEmpty(String attributeName) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - “ Deprecated elements should have both the annotation and the Javadoc tag ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
Please let me know if you have any questions.
Ayman Abdelghany.