### PR TITLE
Boxing and unboxing should not be immediately reversed

### DIFF
--- a/engine/analyser/src/main/java/org/asqatasun/analyser/AnalyserImpl.java
+++ b/engine/analyser/src/main/java/org/asqatasun/analyser/AnalyserImpl.java
@@ -125,8 +125,8 @@ public class AnalyserImpl implements Analyser {
      * the set of audit parameters that handles some overridden values for test
      * weight (needed to compute the raw mark)
      */
-    private final Collection<Parameter> paramSet; 
-    private static final BigDecimal ZERO = BigDecimal.valueOf(Double.valueOf(0.0));
+    private final Collection<Parameter> paramSet;
+    private static final BigDecimal ZERO = BigDecimal.valueOf(0.0);
 
     public AnalyserImpl(
             AuditDataService auditDataService,

--- a/engine/statistics/src/main/java/org/asqatasun/entity/service/statistics/WebResourceStatisticsDataServiceImpl.java
+++ b/engine/statistics/src/main/java/org/asqatasun/entity/service/statistics/WebResourceStatisticsDataServiceImpl.java
@@ -55,7 +55,7 @@ public class WebResourceStatisticsDataServiceImpl extends
         AbstractGenericDataService<WebResourceStatistics, Long> implements
         WebResourceStatisticsDataService {
 
-    private static final BigDecimal ZERO = BigDecimal.valueOf(Double.valueOf(0.0));
+    private static final BigDecimal ZERO = BigDecimal.valueOf(0.0);
 
     private CriterionStatisticsDAO criterionStatisticsDAO;
 

--- a/web-app/tgol-data-presentation/src/main/java/org/asqatasun/webapp/presentation/data/PageResultImpl.java
+++ b/web-app/tgol-data-presentation/src/main/java/org/asqatasun/webapp/presentation/data/PageResultImpl.java
@@ -175,8 +175,8 @@ public class PageResultImpl implements PageResult{
             this.weightedMark = "-1";
             this.rawMark = "-1";
         } else {
-            this.weightedMark = String.valueOf(Float.valueOf(weightedMark).intValue());
-            this.rawMark = String.valueOf(Float.valueOf(rawMark).intValue());
+            this.weightedMark = String.valueOf(weightedMark.intValue());
+            this.rawMark = String.valueOf(rawMark.intValue());
         }
         this.httpStatusCode = String.valueOf(httpStatusCode);
         this.rank = rank;

--- a/web-app/tgol-persistence/src/main/java/org/asqatasun/webapp/entity/dao/contract/ActDAOImpl.java
+++ b/web-app/tgol-persistence/src/main/java/org/asqatasun/webapp/entity/dao/contract/ActDAOImpl.java
@@ -55,7 +55,7 @@ public class ActDAOImpl extends AbstractJPADAO<Act, Long> implements ActDAO {
                 + " WHERE a.contract = :contract");
         query.setParameter("contract", contract);
         query.setHint(CACHEABLE_OPTION, "true");
-        return Long.valueOf((Long)query.getSingleResult()).intValue();
+        return ((Long)query.getSingleResult()).intValue();
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2153 - “Boxing and unboxing should not be immediately reversed”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2153
Please let me know if you have any questions.
Ayman Abdelghany.