### PR TITLE
 Collections.emptyList(), emptyMap() and emptySet() should be used.

### DIFF
--- a/engine/analyser/src/main/java/org/asqatasun/analyser/AnalyserFactoryImpl.java
+++ b/engine/analyser/src/main/java/org/asqatasun/analyser/AnalyserFactoryImpl.java
@@ -122,7 +122,7 @@ public class AnalyserFactoryImpl implements AnalyserFactory {// TODO Write javad
         this.parameterFamilyDataService = parameterFamilyDataService;
     }
 
-    private List<String> testWeightParameterFamilyCodeList = Collections.EMPTY_LIST;
+    private List<String> testWeightParameterFamilyCodeList = Collections.emptyList();
     public void setTestWeightParameterFamilyCodeList(List<String> testWeightParameterFamilyCodeList) {
         this.testWeightParameterFamilyCodeList = testWeightParameterFamilyCodeList;
     }

--- a/engine/contentadapter/src/main/java/org/asqatasun/contentadapter/html/HTMLJsoupParserImpl.java
+++ b/engine/contentadapter/src/main/java/org/asqatasun/contentadapter/html/HTMLJsoupParserImpl.java
@@ -39,7 +39,7 @@ import org.asqatasun.entity.audit.SSP;
  */
 public class HTMLJsoupParserImpl implements HTMLParser {
 
-    protected Set<ContentAdapter> contentAdapterSet = Collections.EMPTY_SET;
+    protected Set<ContentAdapter> contentAdapterSet = Collections.emptySet();
     protected boolean initialized = false;
     protected SSP ssp;
 

--- a/engine/crawler/src/main/java/org/asqatasun/crawler/processor/AsqatasunWriterProcessor.java
+++ b/engine/crawler/src/main/java/org/asqatasun/crawler/processor/AsqatasunWriterProcessor.java
@@ -120,7 +120,7 @@ public class AsqatasunWriterProcessor extends Processor
         this.htmlRegexp = htmlRegexp;
     }
 
-    private Collection<String> authorizedMimeTypes = Collections.EMPTY_LIST;
+    private Collection<String> authorizedMimeTypes = Collections.emptyList();
     public Collection<String> getAuthorizedMimeTypes() {
         return authorizedMimeTypes;
     }

--- a/engine/crawler/src/main/java/org/asqatasun/crawler/util/CrawlConfigurationUtils.java
+++ b/engine/crawler/src/main/java/org/asqatasun/crawler/util/CrawlConfigurationUtils.java
@@ -39,7 +39,7 @@ import org.w3c.dom.Document;
  */
 public class CrawlConfigurationUtils {
 
-    Map<String, HeritrixConfigurationModifier> paramModifierMap = Collections.EMPTY_MAP;
+    Map<String, HeritrixConfigurationModifier> paramModifierMap = Collections.emptyMap();
     /**
      *
      * @param paramModifierMap
@@ -48,7 +48,7 @@ public class CrawlConfigurationUtils {
         this.paramModifierMap = paramModifierMap;
     }
     
-    List<HeritrixConfigurationModifier> proxyModifierList = Collections.EMPTY_LIST;
+    List<HeritrixConfigurationModifier> proxyModifierList = Collections.emptyList();
     /**
      *
      * @param proxyModifierList

--- a/engine/persistence/src/main/java/org/asqatasun/entity/dao/audit/ContentDAOImpl.java
+++ b/engine/persistence/src/main/java/org/asqatasun/entity/dao/audit/ContentDAOImpl.java
@@ -245,7 +245,7 @@ public class ContentDAOImpl extends AbstractJPADAO<Content, Long> implements
             flushAndCloseEntityManager();
             return contentList;
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override
@@ -312,7 +312,7 @@ public class ContentDAOImpl extends AbstractJPADAO<Content, Long> implements
             flushAndCloseEntityManager();
             return contentList;
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/controller/AbstractUserAndContractsController.java
+++ b/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/controller/AbstractUserAndContractsController.java
@@ -457,7 +457,7 @@ public class AbstractUserAndContractsController extends AbstractController{
         emailSender.sendEmail(
                 emailFrom, 
                 emailToSet, 
-                Collections.EMPTY_SET, 
+                Collections.<String>emptySet(), 
                 StringUtils.EMPTY,
                 emailSubject, 
                 emailContent);

--- a/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/controller/ForgottenOrChangePasswordController.java
+++ b/web-app/asqatasun-web-app/src/main/java/org/asqatasun/webapp/controller/ForgottenOrChangePasswordController.java
@@ -426,7 +426,7 @@ public class ForgottenOrChangePasswordController extends AbstractController {
         emailSender.sendEmail(
                 emailFrom, 
                 emailToSet, 
-                Collections.EMPTY_SET, 
+                Collections.<String>emptySet(), 
                 StringUtils.EMPTY, 
                 emailSubject, 
                 emailContent);

--- a/web-app/tgol-data-presentation/src/main/java/org/asqatasun/webapp/form/parameterization/helper/AuditSetUpFormFieldHelper.java
+++ b/web-app/tgol-data-presentation/src/main/java/org/asqatasun/webapp/form/parameterization/helper/AuditSetUpFormFieldHelper.java
@@ -41,7 +41,7 @@ import org.asqatasun.webapp.form.parameterization.AuditSetUpFormField;
  */
 public final class AuditSetUpFormFieldHelper {
 
-    private static Map<String, String> DEFAULT_LEVEL_BY_REF_MAP = Collections.EMPTY_MAP;
+    private static Map<String, String> DEFAULT_LEVEL_BY_REF_MAP = Collections.emptyMap();
     public static void setDefaultLevelByRefMap(Map<String, String> defaultLevelByRef) {
         DEFAULT_LEVEL_BY_REF_MAP = defaultLevelByRef;
     }

--- a/web-app/tgol-data-presentation/src/main/java/org/asqatasun/webapp/presentation/menu/SecondaryLevelMenuDisplayer.java
+++ b/web-app/tgol-data-presentation/src/main/java/org/asqatasun/webapp/presentation/menu/SecondaryLevelMenuDisplayer.java
@@ -42,7 +42,7 @@ import org.springframework.ui.Model;
  */
 public class SecondaryLevelMenuDisplayer {
 
-    List<String> referentialWithModifiableTestWeight = Collections.EMPTY_LIST;
+    List<String> referentialWithModifiableTestWeight = Collections.emptyList();
     public void setReferentialWithModifiableTestWeight(
             List<String> referentialWithModifiableTestWeight) {
         this.referentialWithModifiableTestWeight = referentialWithModifiableTestWeight;

--- a/web-app/tgol-orchestrator/src/main/java/org/asqatasun/webapp/orchestrator/AsqatasunOrchestratorImpl.java
+++ b/web-app/tgol-orchestrator/src/main/java/org/asqatasun/webapp/orchestrator/AsqatasunOrchestratorImpl.java
@@ -479,7 +479,7 @@ public class AsqatasunOrchestratorImpl implements AsqatasunOrchestrator {
         emailSender.sendEmail(
                 emailFrom, 
                 emailToSet, 
-                Collections.EMPTY_SET, 
+                Collections.<String>emptySet(), 
                 StringUtils.EMPTY,
                 emailSubject, 
                 emailMessage);

--- a/web-app/tgol-persistence/src/main/java/org/asqatasun/webapp/entity/dao/statistics/StatisticsDAOImpl.java
+++ b/web-app/tgol-persistence/src/main/java/org/asqatasun/webapp/entity/dao/statistics/StatisticsDAOImpl.java
@@ -254,11 +254,11 @@ public class StatisticsDAOImpl extends AbstractJPADAO<WebResourceStatistics, Lon
         try {
             List<Object[]> result = (List<Object[]>)query.getResultList();
             if (result.isEmpty()) {
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
             return convertRawResultAsFailedThemeInfo(result);
         } catch (NoResultException nre) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 
@@ -333,11 +333,11 @@ public class StatisticsDAOImpl extends AbstractJPADAO<WebResourceStatistics, Lon
         try {
             List<Object[]> result = (List<Object[]>)query.getResultList();
             if (result.isEmpty()) {
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
             return convertRawResultAsFailedTestInfo(result);
         } catch (NoResultException e) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 
@@ -442,11 +442,11 @@ public class StatisticsDAOImpl extends AbstractJPADAO<WebResourceStatistics, Lon
         try {
             List<Object[]> result = (List<Object[]>)query.getResultList();
             if (result.isEmpty()) {
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
             return convertRawResultAsFailedPageInfo(result);
         } catch (NoResultException e) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 
@@ -498,11 +498,11 @@ public class StatisticsDAOImpl extends AbstractJPADAO<WebResourceStatistics, Lon
         try {
             List<Object[]>  result = (List<Object[]>)query.getResultList();
             if (result.isEmpty()) {
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
             return convertRawResultAsFailedPageInfo(result);
         } catch (NoResultException e) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 
@@ -794,11 +794,11 @@ public class StatisticsDAOImpl extends AbstractJPADAO<WebResourceStatistics, Lon
         try {
             List<Object[]> result = (List<Object[]>)query.getResultList();
             if (result.isEmpty()) {
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
             return convertRawResultAsPageResultSet(result);
         } catch (NoResultException e) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1596 - “Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1596
Please let me know if you have any questions.
Ayman Abdelghany.