### PR TITLE
Fix for #243 "Build on debian/ubuntu: failed to execute goal maven-surefire"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,13 @@
                 <configuration> 
 <!--                    <skipTests>true</skipTests>-->
                     <encoding>UTF-8</encoding>
+
+                <!-- Fixes a bug related to the surefire plugin
+                     that will be solved in the next version of the plugin (after 2.22.1)
+                                   and we can then remove this patch
+                     see:   https://github.com/Asqatasun/Asqatasun/issues/243
+                            https://issues.apache.org/jira/browse/SUREFIRE-1588     -->
+                    <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## I verified my work is based on `develop` branch
* [X] yes, keep going

## Related issue
#243 "Build on debian/ubuntu: failed to execute goal maven-surefire"

## Purpose of this Pull Request?
This is a temporary fix until the surefire team
have fixed this in a new plugin version (after 2.22.1)

## How the PR could be tested?
```bash
mvn clean install
```

