### PR TITLE
dependencies / upgraded versions: spring*, hibernate, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,11 +217,11 @@
         <asqatasunVersion>4.1.0-SNAPSHOT</asqatasunVersion>
         
         <springGroupId>org.springframework</springGroupId>
-        <springVersion>4.3.21.RELEASE</springVersion>
-        <springSecurityVersion>4.2.10.RELEASE</springSecurityVersion>
+        <springVersion>4.3.24.RELEASE</springVersion>
+        <springSecurityVersion>4.2.13.RELEASE</springSecurityVersion>
 
         <hibernateGroupId>org.hibernate</hibernateGroupId>
-        <hibernateVersion>4.3.8.Final</hibernateVersion>
+        <hibernateVersion>4.3.11.Final</hibernateVersion>
 
         <log4jGroupId>log4j</log4jGroupId>
         <log4jVersion>1.2.15</log4jVersion>
@@ -972,7 +972,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.7</version>
+                <version>3.9</version>
             </dependency>
             <dependency>
                 <groupId>commons-collections</groupId>
@@ -982,12 +982,12 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.10</version>
+                <version>1.12</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.5</version>
+                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
@@ -1017,7 +1017,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.9</version>
+                <version>4.4.11</version>
             </dependency>
             <dependency>
                 <groupId>commons-dbcp</groupId>
@@ -1034,7 +1034,7 @@
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.9</version>
+                <version>1.4.11.1</version>
             </dependency>
 
             <!-- htmlCleaner dependencies -->
@@ -1077,7 +1077,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.5</version>
+                <version>4.5.9</version>
             </dependency>
 
             <!-- aspectj dependencies -->


### PR DESCRIPTION
related to c3ba7d3115b

- springFramework:    4.3.24      instead of  4.3.21
- springSecurity:         4.2.13      instead of  4.2.10
- hibernate:  		4.3.11     instead of  4.3.8
- commons-lang3:   3.9          instead of  3.7
- commons-codec:  	1.12       instead of  1.10
- commons-io:  		2.6         instead of  2.5
- httpcore:   		4.4.11    instead of  4.4.9
- xstream:   		1.4.11.1 instead of  1.4.9
- httpclient:    		4.5.9      instead of  4.5.5
