### PR TITLE
#326 - v4.1: Update pom.xml, https for repo1.maven.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     </properties>
     <repositories>
         <repository>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
             <id>central</id>
             <releases>
                 <enabled>true</enabled>


### PR DESCRIPTION
## What are the related issues?
Fixed #326 HTTPS required for repo1.maven.org
